### PR TITLE
Improve CPU and network labels

### DIFF
--- a/i18n/en/cosmic_applet_minimon.ftl
+++ b/i18n/en/cosmic_applet_minimon.ftl
@@ -12,3 +12,4 @@ net-bandwidth = Network speed
 refresh-rate = Refresh rate (seconds)
 network-colors = Network Colors
 change-colors = Change colors
+change-label-size = Label size

--- a/i18n/nl/cosmic_applet_minimon.ftl
+++ b/i18n/nl/cosmic_applet_minimon.ftl
@@ -12,3 +12,4 @@ net-bandwidth = Netwerksnelheid
 refresh-rate = Vernieuwingsfrequentie (secondes)
 network-colors = As kleuren netwerkgrafiek
 change-colors = As kleuren wijzigen
+change-label-size = Label size

--- a/i18n/sv/cosmic_applet_minimon.ftl
+++ b/i18n/sv/cosmic_applet_minimon.ftl
@@ -12,3 +12,4 @@ net-bandwidth = Nätverkshastighet
 refresh-rate = Uppdateringshastighet (sekunder)
 network-colors = Nätverksfärger
 change-colors = Ändra färger
+change-label-size = Label size

--- a/src/app.rs
+++ b/src/app.rs
@@ -251,27 +251,29 @@ impl cosmic::Application for Minimon {
             let mut network_labels: Vec<Element<Message>> = Vec::new();
 
             // DL
-            let dlstr = match horizontal {
-                true => format!(
+            let dl_label = match horizontal {
+                true => self.core.applet.text(format!(
                     "↓ {}",
                     &self.netmon.get_bitrate_dl(ticks_per_sec, UnitVariant::Long)
+                )).size(13),
+                false => self.core.applet.text(
+                    self.netmon
+                        .get_bitrate_dl(ticks_per_sec, UnitVariant::Short),
                 ),
-                false => self
-                    .netmon
-                    .get_bitrate_dl(ticks_per_sec, UnitVariant::Short),
             };
-            network_labels.push(self.core.applet.text(dlstr).into());
+            network_labels.push(dl_label.into());
             // UL
-            let ulstr = match horizontal {
-                true => format!(
+            let ul_label = match horizontal {
+                true => self.core.applet.text(format!(
                     "↑ {}",
                     &self.netmon.get_bitrate_ul(ticks_per_sec, UnitVariant::Long)
+                )).size(13),
+                false => self.core.applet.text(
+                    self.netmon
+                        .get_bitrate_ul(ticks_per_sec, UnitVariant::Short),
                 ),
-                false => self
-                    .netmon
-                    .get_bitrate_ul(ticks_per_sec, UnitVariant::Short),
             };
-            network_labels.push(self.core.applet.text(ulstr).into());
+            network_labels.push(ul_label.into());
 
             elements.push(Column::from_vec(network_labels).into());
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -440,10 +440,8 @@ impl cosmic::Application for Minimon {
 
             let ticks_per_sec = (1000 / self.tick.clone().load(atomic::Ordering::Relaxed)) as usize;
 
-            let mut dlrate = '↓'.to_string();
-            dlrate.push_str(&self.netmon.get_bitrate_dl(ticks_per_sec, UnitVariant::Long));
-            let mut ulrate = '↑'.to_string();
-            ulrate.push_str(&self.netmon.get_bitrate_ul(ticks_per_sec, UnitVariant::Long));
+            let dlrate = format!("↓ {}", &self.netmon.get_bitrate_dl(ticks_per_sec, UnitVariant::Long));
+            let ulrate = format!("↑ {}", &self.netmon.get_bitrate_ul(ticks_per_sec, UnitVariant::Long));
 
             net_elements.push(Element::from(
                 column!(

--- a/src/app.rs
+++ b/src/app.rs
@@ -265,6 +265,7 @@ impl cosmic::Application for Minimon {
                         .get_bitrate_dl(ticks_per_sec, UnitVariant::Short),
                 ),
             };
+            network_labels.push(widget::vertical_space().into());
             network_labels.push(dl_label.into());
             // UL
             let ul_label = match horizontal {
@@ -278,6 +279,7 @@ impl cosmic::Application for Minimon {
                 ),
             };
             network_labels.push(ul_label.into());
+            network_labels.push(widget::vertical_space().into());
 
             elements.push(Column::from_vec(network_labels).into());
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -209,7 +209,7 @@ impl cosmic::Application for Minimon {
             format!("{:.1}%", self.svgstat_cpu.latest_sample())
         };
 
-        let formated_mem = format!("{:.1}GB", self.svgstat_mem.latest_sample());
+        let formated_mem = format!("{:.1} GB", self.svgstat_mem.latest_sample());
 
         // vertical layout
         let mut elements: Vec<Element<Message>> = Vec::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,6 +149,8 @@ pub struct MinimonConfig {
     pub cpu_colors: GraphColors,
     pub mem_colors: GraphColors,
     pub net_colors: GraphColors,
+    /// The minimum size of labels
+    pub label_size_default: u16,
 }
 
 impl Default for MinimonConfig {
@@ -169,6 +171,7 @@ impl Default for MinimonConfig {
             cpu_colors: GraphColors::new(DeviceKind::Cpu(GraphKind::Ring)),
             mem_colors: GraphColors::new(DeviceKind::Memory(GraphKind::Line)),
             net_colors: GraphColors::new(DeviceKind::Network(GraphKind::Line)),
+            label_size_default: 11,
         }
     }
 }

--- a/src/netmon.rs
+++ b/src/netmon.rs
@@ -136,11 +136,11 @@ impl NetMon {
         }
 
         if value < 10.0 {
-            format!("{:.2}{}", value, units[unit_index])
+            format!("{:.2} {}", value, units[unit_index])
         } else if value < 99.0 {
-            format!("{:.1}{}", value, units[unit_index])
+            format!("{:.1} {}", value, units[unit_index])
         } else {
-            format!("{:.0}{}", value, units[unit_index])
+            format!("{:.0} {}", value, units[unit_index])
         }
     }
 

--- a/src/svgstat.rs
+++ b/src/svgstat.rs
@@ -139,7 +139,7 @@ impl SvgStat {
         let current_val = self.latest_sample();
         let unit = match self.kind {
             SvgDevKind::Cpu(_) => "%",
-            SvgDevKind::Memory(_) => "GB",
+            SvgDevKind::Memory(_) => " GB",
             _ => panic!("ERROR: Wrong kind {:?}", self.kind),
         };
 

--- a/src/svgstat.rs
+++ b/src/svgstat.rs
@@ -138,8 +138,8 @@ impl SvgStat {
     pub fn to_string(&self) -> String {
         let current_val = self.latest_sample();
         let unit = match self.kind {
-            SvgDevKind::Cpu(_) => "%",
-            SvgDevKind::Memory(_) => " GB",
+            DeviceKind::Cpu(_) => "%",
+            DeviceKind::Memory(_) => " GB",
             _ => panic!("ERROR: Wrong kind {:?}", self.kind),
         };
 


### PR DESCRIPTION
# Changes

- CPU labels only have 1 decimal at most on vertical panels
- Network labels are stacked on top of each other without overflowing the panel, except for on the very smallest horizontal setting - see discussion
- Network arrows have a space between them and their text content: improves readability

# Discussion

- Maybe we want to make stacking the network layers configurable. Personally I don't see why you'd prefer to use more space than less though
- We may want to reduce text size of the labels to allow for a better "fit" in the panel, since we are struggling with space. For the smallest panel size, it really struggles to look right. Maybe we do this dynamically based on panel size.

# Media

![Screenshot_2025-03-17_12-21-55](https://github.com/user-attachments/assets/2a8c6d29-b089-4e1b-b505-4d002964b3a1)
![Screenshot_2025-03-17_12-21-43](https://github.com/user-attachments/assets/3d4bd5ab-1ae3-4143-8922-879db6fc89b9)
