### PR TITLE
feat: replace global symbols toggle with per-sensor icon visibility

### DIFF
--- a/i18n/en/cosmic_applet_minimon.ftl
+++ b/i18n/en/cosmic_applet_minimon.ftl
@@ -3,6 +3,7 @@ cpu-temperature-title = CPU Temperature
 temperature-unit = Temperature unit
 enable-chart = Show chart
 enable-label = Show label
+enable-icon = Show icon
 net-title = Network load
 net-title-combined = Network load in bits per second
 net-title-dl = Network download in bits per second

--- a/src/app.rs
+++ b/src/app.rs
@@ -226,6 +226,7 @@ pub enum Message {
     ToggleNetCombined(bool),
     ToggleNetChart(NetworkVariant, bool),
     ToggleNetLabel(NetworkVariant, bool),
+    ToggleNetIcon(NetworkVariant, bool),
     ToggleAdaptiveNet(NetworkVariant, bool),
     NetworkSelectUnit(NetworkVariant, usize),
     TextInputBandwidthChanged(NetworkVariant, String),
@@ -233,6 +234,7 @@ pub enum Message {
     ToggleDisksCombined(bool),
     ToggleDisksChart(DisksVariant, bool),
     ToggleDisksLabel(DisksVariant, bool),
+    ToggleDisksIcon(DisksVariant, bool),
 
     SelectGraphType(DeviceKind, ChartKind),
     Tick,
@@ -241,13 +243,16 @@ pub enum Message {
 
     ToggleCpuChart(bool),
     ToggleCpuLabel(bool),
+    ToggleCpuIcon(bool),
     ToggleCpuTempChart(bool),
     ToggleCpuTempLabel(bool),
+    ToggleCpuTempIcon(bool),
     ToggleCpuNoDecimals(bool),
     CpuBarSizeChanged(u16),
     CpuNarrowBarSpacing(bool),
     ToggleMemoryChart(bool),
     ToggleMemoryLabel(bool),
+    ToggleMemoryIcon(bool),
     ToggleMemoryPercentage(bool),
     ToggleMemoryAllocated(bool),
     ConfigChanged(Box<MinimonConfig>),
@@ -264,12 +269,12 @@ pub enum Message {
 
     GpuToggleChart(String, DeviceKind, bool),
     GpuToggleLabel(String, DeviceKind, bool),
+    GpuToggleIcon(String, bool),
     GpuToggleStackLabels(String, bool),
     GpuSelectGraphType(String, DeviceKind, ChartKind),
     SelectGpuTempUnit(String, TempUnit),
     GpuTempMinTempChanged(String, f64),
     ToggleDisableOnBattery(String, bool),
-    ToggleSymbols(bool),
     SysmonSelect(usize),
 
     ChangeContentOrder(ContentOrderChange),
@@ -907,6 +912,13 @@ impl cosmic::Application for Minimon {
                 self.save_config();
             }
 
+            Message::ToggleDisksIcon(variant, toggled) => {
+                info!("Message::ToggleDisksIcon({variant:?})");
+                let (_, config) = disks_select!(self, variant);
+                config.show_icon(toggled);
+                self.save_config();
+            }
+
             Message::ToggleAdaptiveNet(variant, toggle) => {
                 info!("Message::ToggleAdaptiveNet({variant:?}, {toggle:?})");
                 let (_network, config) = network_select!(self, variant);
@@ -1047,15 +1059,33 @@ impl cosmic::Application for Minimon {
                 self.save_config();
             }
 
+            Message::ToggleCpuIcon(toggled) => {
+                info!("Message::ToggleCpuIcon({toggled:?})");
+                self.config.cpu.show_icon(toggled);
+                self.save_config();
+            }
+
             Message::ToggleCpuTempLabel(toggled) => {
                 info!("Message::ToggleCpuTempLabel({toggled:?})");
                 self.config.cputemp.show_label(toggled);
                 self.save_config();
             }
 
+            Message::ToggleCpuTempIcon(toggled) => {
+                info!("Message::ToggleCpuTempIcon({toggled:?})");
+                self.config.cputemp.show_icon(toggled);
+                self.save_config();
+            }
+
             Message::ToggleMemoryLabel(toggled) => {
                 info!("Message::ToggleMemoryLabel({toggled:?})");
                 self.config.memory.show_label(toggled);
+                self.save_config();
+            }
+
+            Message::ToggleMemoryIcon(toggled) => {
+                info!("Message::ToggleMemoryIcon({toggled:?})");
+                self.config.memory.show_icon(toggled);
                 self.save_config();
             }
 
@@ -1075,6 +1105,13 @@ impl cosmic::Application for Minimon {
                 info!("Message::ToggleNetLabel({toggled:?})");
                 let (_, config) = network_select!(self, variant);
                 config.show_label(toggled);
+                self.save_config();
+            }
+
+            Message::ToggleNetIcon(variant, toggled) => {
+                info!("Message::ToggleNetIcon({toggled:?})");
+                let (_, config) = network_select!(self, variant);
+                config.show_icon(toggled);
                 self.save_config();
             }
 
@@ -1136,12 +1173,6 @@ impl cosmic::Application for Minimon {
                 self.save_config();
             }
 
-            Message::ToggleSymbols(toggle) => {
-                info!("Message::ToggleSymbols({toggle:?})");
-                self.config.symbols = toggle;
-                self.save_config();
-            }
-
             Message::Settings(setting) => {
                 info!("Message::Settings({setting:?})");
                 self.settings_page = setting;
@@ -1178,6 +1209,16 @@ impl cosmic::Application for Minimon {
                         _ => error!("GpuToggleLabel: wrong kind {device:?}"),
                     },
                 );
+            }
+
+            Message::GpuToggleIcon(id, toggled) => {
+                info!("Message::GpuToggleIcon({id:?}, {toggled:?})");
+                if let Some(c) = self.config.gpus.get_mut(&id) {
+                    c.usage.show_icon(toggled);
+                    self.save_config();
+                } else {
+                    error!("GpuToggleIcon: wrong id {id:?}");
+                }
             }
 
             Message::SelectGpuTempUnit(id, unit) => {
@@ -1413,11 +1454,6 @@ impl Minimon {
             ),
         );
 
-        let symbol_row = settings::item(
-            fl!("enable-symbols"),
-            widget::toggler(self.config.symbols).on_toggle(Message::ToggleSymbols),
-        );
-
         let spacing_row = settings::item(
             fl!("settings-panel-spacing"),
             widget::row::with_children(vec![
@@ -1503,7 +1539,6 @@ impl Minimon {
             refresh_row,
             label_row,
             mono_row,
-            symbol_row,
             spacing_row,
             sysmon_row,
             content_order
@@ -1536,8 +1571,7 @@ impl Minimon {
 
         let mut elements: VecDeque<Element<Message>> = VecDeque::new();
 
-        // Handle the symbols button if needed
-        if self.config.symbols
+        if self.config.cpu.icon_visible()
             && (self.config.cpu.label_visible() || self.config.cpu.chart_visible())
         {
             self.push_symbolic_icon(&mut elements, CPU_ICON, false);
@@ -1594,8 +1628,7 @@ impl Minimon {
         let mut elements: VecDeque<Element<Message>> = VecDeque::new();
 
         if self.cputemp.is_found() {
-            // Handle the symbols button if needed
-            if self.config.symbols
+            if self.config.cputemp.icon_visible()
                 && (self.config.cputemp.label_visible() || self.config.cputemp.chart_visible())
             {
                 self.push_symbolic_icon(&mut elements, TEMP_ICON, false);
@@ -1626,8 +1659,7 @@ impl Minimon {
 
         let mut elements: VecDeque<Element<Message>> = VecDeque::new();
 
-        // Handle the symbols button if needed
-        if self.config.symbols
+        if self.config.memory.icon_visible()
             && (self.config.memory.label_visible() || self.config.memory.chart_visible())
         {
             self.push_symbolic_icon(&mut elements, RAM_ICON, false);
@@ -1736,7 +1768,7 @@ impl Minimon {
             );
         }
 
-        if self.config.symbols && !elements.is_empty() {
+        if self.config.network1.icon_visible() && !elements.is_empty() {
             self.push_symbolic_icon(&mut elements, NETWORK_ICON, true);
         }
 
@@ -1820,7 +1852,7 @@ impl Minimon {
             );
         }
 
-        if self.config.symbols && !elements.is_empty() {
+        if self.config.disks1.icon_visible() && !elements.is_empty() {
             self.push_symbolic_icon(&mut elements, DISK_ICON, true);
         }
 
@@ -1878,8 +1910,10 @@ impl Minimon {
             }
         }
 
-        if self.config.symbols && !elements.is_empty() {
-            self.push_symbolic_icon(&mut elements, GPU_ICON, true);
+        if let Some(config) = self.config.gpus.get(&gpu.id()) {
+            if config.usage.icon_visible() && !elements.is_empty() {
+                self.push_symbolic_icon(&mut elements, GPU_ICON, true);
+            }
         }
 
         elements

--- a/src/config.rs
+++ b/src/config.rs
@@ -270,6 +270,7 @@ macro_rules! make_config {
         pub struct $name {
             chart_visible: bool,
             label_visible: bool,
+            icon_visible: bool,
             pub chart: ChartKind,
             colors: Colors,
             $($extra)*
@@ -285,11 +286,17 @@ macro_rules! make_config {
             pub fn label_visible(&self) -> bool {
                 self.label_visible
             }
+            pub fn icon_visible(&self) -> bool {
+                self.icon_visible
+            }
             pub fn show_chart(&mut self, visible: bool) {
                 self.chart_visible = visible;
             }
             pub fn show_label(&mut self, visible: bool) {
                 self.label_visible = visible;
+            }
+            pub fn show_icon(&mut self, visible: bool) {
+                self.icon_visible = visible;
             }
             pub fn colors(&self) -> &ChartColors {
                 self.colors.get(self.chart)
@@ -312,6 +319,7 @@ impl Default for CpuConfig {
         Self {
             chart_visible: true,
             label_visible: false,
+            icon_visible: true,
             chart: ChartKind::Ring,
             colors: Colors::new(DeviceKind::Cpu),
             no_decimals: false,
@@ -331,6 +339,7 @@ impl Default for CpuTempConfig {
         Self {
             chart_visible: false,
             label_visible: false,
+            icon_visible: true,
             chart: ChartKind::Heat,
             colors: Colors::new(DeviceKind::CpuTemp),
             unit: TempUnit::Celsius,
@@ -350,6 +359,7 @@ impl Default for MemoryConfig {
         Self {
             chart_visible: true,
             label_visible: false,
+            icon_visible: true,
             chart: ChartKind::Ring,
             colors: Colors::new(DeviceKind::Memory),
             percentage: false,
@@ -379,6 +389,7 @@ impl Default for NetworkConfig {
         Self {
             chart_visible: true,
             label_visible: false,
+            icon_visible: true,
             chart: ChartKind::Line,
             colors: Colors::new(DeviceKind::Network(NetworkVariant::Combined)),
             adaptive: true,
@@ -406,6 +417,7 @@ impl Default for DisksConfig {
         Self {
             chart_visible: false,
             label_visible: false,
+            icon_visible: true,
             chart: ChartKind::Line,
             colors: Colors::new(DeviceKind::Disks(DisksVariant::Combined)),
             variant: DisksVariant::Combined,
@@ -420,6 +432,7 @@ impl Default for GpuUsageConfig {
         Self {
             chart_visible: true,
             label_visible: false,
+            icon_visible: true,
             chart: ChartKind::Ring,
             colors: Colors::new(DeviceKind::Gpu),
         }
@@ -433,6 +446,7 @@ impl Default for GpuVramConfig {
         Self {
             chart_visible: true,
             label_visible: false,
+            icon_visible: true,
             chart: ChartKind::Ring,
             colors: Colors::new(DeviceKind::Vram),
         }
@@ -449,6 +463,7 @@ impl Default for GpuTempConfig {
         Self {
             chart_visible: false,
             label_visible: false,
+            icon_visible: true,
             chart: ChartKind::Ring,
             colors: Colors::new(DeviceKind::GpuTemp),
             unit: TempUnit::Celsius,
@@ -537,7 +552,6 @@ pub struct MinimonConfig {
 
     pub sysmon: Option<String>,
 
-    pub symbols: bool,
     pub panel_spacing: u16,
 
     pub content_order: ContentOrder,
@@ -570,7 +584,6 @@ impl Default for MinimonConfig {
             },
             gpus: HashMap::new(),
             sysmon: None,
-            symbols: false,
             panel_spacing: 3, // Slider setting for cosmic.space_xs()
             content_order: ContentOrder::default(),
         }

--- a/src/sensors/cpu.rs
+++ b/src/sensors/cpu.rs
@@ -376,6 +376,13 @@ impl Sensor for Cpu {
             )
             .into(),
         );
+        cpu_column.push(
+            settings::item(
+                fl!("enable-icon"),
+                toggler(config.icon_visible()).on_toggle(Message::ToggleCpuIcon),
+            )
+            .into(),
+        );
         if self.config.label_visible() {
             cpu_column.push(
                 settings::item(

--- a/src/sensors/cputemp.rs
+++ b/src/sensors/cputemp.rs
@@ -381,6 +381,11 @@ impl Sensor for CpuTemp {
                         .on_toggle(|value| { Message::ToggleCpuTempLabel(value) }),
                 ),
                 settings::item(
+                    fl!("enable-icon"),
+                    toggler(config.icon_visible())
+                        .on_toggle(|value| { Message::ToggleCpuTempIcon(value) }),
+                ),
+                settings::item(
                     fl!("temperature-unit"),
                     widget::dropdown(&self.unit_options, selected_unit, |m| {
                         Message::SelectCpuTempUnit(m.into())

--- a/src/sensors/disks.rs
+++ b/src/sensors/disks.rs
@@ -309,6 +309,14 @@ impl Sensor for Disks {
             )
             .into(),
         );
+        disk_bandwidth_items.push(
+            settings::item(
+                fl!("enable-icon"),
+                widget::toggler(config.icon_visible())
+                    .on_toggle(move |t| Message::ToggleDisksIcon(k, t)),
+            )
+            .into(),
+        );
 
         disk_bandwidth_items.push(
             row!(

--- a/src/sensors/gpus.rs
+++ b/src/sensors/gpus.rs
@@ -1082,6 +1082,13 @@ impl Gpu {
             None
         };
 
+        let icon_toggle = settings::item(
+            fl!("enable-icon"),
+            widget::toggler(config.usage.icon_visible()).on_toggle(move |value| {
+                Message::GpuToggleIcon(self.id().clone(), value)
+            }),
+        );
+
         let usage = self.settings_usage_ui(&config.usage);
         let vram = self.settings_vram_ui(&config.vram);
 
@@ -1102,6 +1109,7 @@ impl Gpu {
 
         Column::new()
             .push_maybe(battery_disable)
+            .push(icon_toggle)
             .push(usage)
             .push(temp)
             .push(vram)

--- a/src/sensors/memory.rs
+++ b/src/sensors/memory.rs
@@ -330,6 +330,11 @@ impl Sensor for Memory {
                         .on_toggle(|value| { Message::ToggleMemoryLabel(value) }),
                 ),
                 settings::item(
+                    fl!("enable-icon"),
+                    toggler(config.icon_visible())
+                        .on_toggle(|value| { Message::ToggleMemoryIcon(value) }),
+                ),
+                settings::item(
                     fl!("memory-as-percentage"),
                     toggler(config.percentage).on_toggle(Message::ToggleMemoryPercentage),
                 ),

--- a/src/sensors/network.rs
+++ b/src/sensors/network.rs
@@ -334,6 +334,14 @@ impl Sensor for Network {
         );
         net_bandwidth_items.push(
             settings::item(
+                fl!("enable-icon"),
+                widget::toggler(config.icon_visible())
+                    .on_toggle(move |t| Message::ToggleNetIcon(k, t)),
+            )
+            .into(),
+        );
+        net_bandwidth_items.push(
+            settings::item(
                 fl!("use-adaptive"),
                 row!(
                     widget::checkbox(config.adaptive)


### PR DESCRIPTION
opinionated fix for #116.
no migration plan for symbols. Should be fine IMO